### PR TITLE
Add support for testing with JSON post data

### DIFF
--- a/src/MvcRouteTester.AspNetCore.Tests/PostJsonDataTests.cs
+++ b/src/MvcRouteTester.AspNetCore.Tests/PostJsonDataTests.cs
@@ -1,0 +1,73 @@
+﻿#region License
+// Copyright (c) Niklas Wendel 2018-2019
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+#endregion
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+using TestWebApplication.Controllers;
+using TestWebApplication.Model;
+
+namespace MvcRouteTester.AspNetCore.Tests
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class PostJsonDataTests : IClassFixture<TestServerFixture>
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private readonly TestServer _server;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public PostJsonDataTests(TestServerFixture testServerFixture)
+        {
+            _server = testServerFixture.Server;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Fact]
+        public async Task CanPostJsonPerson()
+        {
+            await RouteAssert.ForAsync(
+                _server,
+                request => request
+                    .WithPathAndQuery("/post-with-json-person")
+                    .WithMethod(HttpMethod.Post)
+                    .WithJsonData(new Person
+                    {
+                        FirstName = "Niklas",
+                        LastName = "Wendel"
+                    }),
+                routeAssert => routeAssert
+                    .MapsTo<PostController>(a => a.WithJsonPerson(Args.Any<Person>()))
+                    .ForParameter<Person>("person", p =>
+                    {
+                        Assert.Equal("Niklas", p.FirstName);
+                        Assert.Equal("Wendel", p.LastName);
+                    }));
+        }
+
+    }
+
+}

--- a/src/MvcRouteTester.AspNetCore/Builders/IRequestBuilder.cs
+++ b/src/MvcRouteTester.AspNetCore/Builders/IRequestBuilder.cs
@@ -58,6 +58,16 @@ namespace MvcRouteTester.AspNetCore.Builders
 
         #endregion
 
+        #region With Json Data
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        IRequestBuilder WithJsonData(object jsonData);
+
+        #endregion
+
     }
 
 }

--- a/src/MvcRouteTester.AspNetCore/Builders/RouteTesterRequest.cs
+++ b/src/MvcRouteTester.AspNetCore/Builders/RouteTesterRequest.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.TestHost;
+using MvcRouteTester.AspNetCore.Internal;
 
 namespace MvcRouteTester.AspNetCore.Builders
 {
@@ -34,6 +35,7 @@ namespace MvcRouteTester.AspNetCore.Builders
         private HttpMethod _method = HttpMethod.Get;
         private string _pathAndQuery = "/";
         private IDictionary<string, string> _formData = new Dictionary<string, string>();
+        private object _jsonData = null;
 
         #endregion
 
@@ -86,6 +88,21 @@ namespace MvcRouteTester.AspNetCore.Builders
             return this;
         }
 
+        // <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public IRequestBuilder WithJsonData(object jsonData)
+        {
+            if (jsonData == null)
+            {
+                throw new ArgumentNullException(nameof(jsonData));
+            }
+
+            _jsonData = jsonData;
+            return this;
+        }
+
         #endregion
 
         #region Execute Async
@@ -100,9 +117,16 @@ namespace MvcRouteTester.AspNetCore.Builders
             var requestMessage = new HttpRequestMessage(_method, _pathAndQuery);
 
             // REVIEW: Only with POST method?
-            if (_method == HttpMethod.Post && _formData.Any())
+            if (_method == HttpMethod.Post)
             {
-                requestMessage.Content = new FormUrlEncodedContent(_formData);
+                if (_formData.Any())
+                {
+                    requestMessage.Content = new FormUrlEncodedContent(_formData);
+                }
+                else if (_jsonData != null)
+                {
+                    requestMessage.Content = _jsonData.ToHttpContent();
+                }
             }
 
             var responseMessage = await client.SendAsync(requestMessage);
@@ -112,5 +136,4 @@ namespace MvcRouteTester.AspNetCore.Builders
         #endregion
         
     }
-
 }

--- a/src/MvcRouteTester.AspNetCore/Internal/Extensions.cs
+++ b/src/MvcRouteTester.AspNetCore/Internal/Extensions.cs
@@ -15,7 +15,12 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Newtonsoft.Json;
 
 namespace MvcRouteTester.AspNetCore.Internal
 {
@@ -78,6 +83,36 @@ namespace MvcRouteTester.AspNetCore.Internal
 
         #endregion
 
+        #region Object / Get HttpContent
+
+        public static HttpContent ToHttpContent(this object data)
+        {
+            HttpContent httpContent = null;
+
+            if (data != null)
+            {
+                var ms = new MemoryStream();
+                SerializeJsonIntoStream(data, ms);
+                ms.Seek(0, SeekOrigin.Begin);
+                httpContent = new StreamContent(ms);
+                httpContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            }
+
+            return httpContent;
+        }
+
+        private static void SerializeJsonIntoStream(object value, Stream stream)
+        {
+            using (var sw = new StreamWriter(stream, new UTF8Encoding(false), 1024, true))
+            using (var jtw = new JsonTextWriter(sw) { Formatting = Formatting.None })
+            {
+                var js = new JsonSerializer();
+                js.Serialize(jtw, value);
+                jtw.Flush();
+            }
+        }
+
+        #endregion
     }
 
 }

--- a/src/TestWebApplication/Controllers/PostController.cs
+++ b/src/TestWebApplication/Controllers/PostController.cs
@@ -45,6 +45,12 @@ namespace TestWebApplication.Controllers
             throw new NotImplementedException();
         }
 
+        [HttpPost("post-with-json-person")]
+        public IActionResult WithJsonPerson([FromBody] Person person)
+        {
+            throw new NotImplementedException();
+        }
+
     }
 
 }


### PR DESCRIPTION
Hi @nwendel , I found your package quite interesting and I started using it.  I realized I couldn't  test actions with `[FromBody]` attributes such as the following:
```csharp
[HttpPost("post-with-json-person")]
public IActionResult WithJsonPerson([FromBody] Person person)
{
    throw new NotImplementedException();
}
```
I created a `WithJsonData` function for adding this functionality. Now you can test this type of actions as follow:
```csharp
public async Task CanPostJsonPerson()
{
    await RouteAssert.ForAsync(
        _server,
        request => request
            .WithPathAndQuery("/post-with-json-person")
            .WithMethod(HttpMethod.Post)
            .WithJsonData(new Person
            {
                FirstName = "Niklas",
                LastName = "Wendel"
            }),
        routeAssert => routeAssert
            .MapsTo<PostController>(a => a.WithJsonPerson(Args.Any<Person>()))
            .ForParameter<Person>("person", p =>
            {
                Assert.Equal("Niklas", p.FirstName);
                Assert.Equal("Wendel", p.LastName);
            }));
}
```


Could do you update the package to support this as well? 

Kind regards, 

Chris S.
